### PR TITLE
Remove any mention of Bootloader v1.0

### DIFF
--- a/firmware/programming/usb.mkd
+++ b/firmware/programming/usb.mkd
@@ -8,13 +8,6 @@ bootloader (the OpenXC fork of the [OpenLPC USB
 Bootloader](https://github.com/openxc/openlpc-USB_Bootloader)). This means you
 can re-flash the device using USB, with no extra hardware required.
 
-There are two versions of the bootloader in the prototype units:
-
-   * If your prototype reference VI has an OpenXC sticker covering the housing,
-     your unit has the v1.1 bootloader.
-   * Otherwise, your VI does not have a sticker on it and you  have the v1.0
-     bootloader.
-
 <p>
 To verify the VI was flashed correctly, we recommend trying the
 <a href="http://openxcplatform.com/android/getting-started.html">Android "smoke test"</a> to make sure everything's working.
@@ -61,16 +54,6 @@ bit more involved if you're not already familiar with the tools.
 
             <p>Eject the LPC1759 drive and unplug the VI. It's flashed!</p>
 
-            <hr/>
-
-            <p>
-            If your VI has the v1.0 bootloader, i.e. it <strong>does not</strong> have OpenXC sticker, you must flash new firmware from
-            the command line. Open the Terminal app and run this to update the
-            firmware, assuming the file "newfirmware.bin" is in the current
-            directory and is the new version of the firmware you want to flash:
-
-              <pre><code>$ cp newfirmware.bin /Volumes/LPC1759/firmware.bin</code></pre>
-            </p>
 
             <p>Eject the LPC1759 drive and unplug the VI. It's flashed!</p>
             
@@ -117,28 +100,6 @@ bit more involved if you're not already familiar with the tools.
             file and copy your new firmware file .bin over (the new filename
             doesn't matter). Eject the LPC1759 drive and unplug the VI. It's
             flashed!
-            </p>
-
-            <hr/>
-
-            <p>
-            If your VI has the v1.0 bootloader, i.e. it <strong>does
-            not</strong> have OpenXC sticker, you must flash new firmware from
-            the command line with <code>mdel</code> and <code>mcopy</code>
-            from the <code>mtools</code> package. Once you have
-            <code>mtools</code>, clone the vi-firmware repository and run the
-            bootloader-flash.sh script to program the VI:
-
-            <pre>$ git clone https://github.com/openxc/vi-firmware
-$ cd vi-firmware
-vi-firmware/ $ script/bootloader-flash.sh /dev/sdc new-vi-firmware.bin</pre>
-
-            where <code>/dev/sdc</code> is the device name of the LPC17xx (run
-            <code>dmesg</code> to see what device it appears as when you plug it
-            in with the bootloader button pressed down) and
-            <code>new-vi-firmware.bin</code> is the binary firmware you want to
-            flash, and it's located in the current directory. When the script
-            exists, the VI is flashed - just unplug it.
             </p>
 
          </div>

--- a/index.mkd
+++ b/index.mkd
@@ -62,6 +62,8 @@ for the reference VI in your car.
       follow the <a href="/firmware/programming/usb.html">USB programming
       instructions</a>.</p>
 
+    </div>
+
     <div class="tab-pane" id="firmware-devs">
 
       <p>Besides using <a
@@ -76,6 +78,7 @@ for the reference VI in your car.
       <p>Alternatively, you can use one of a few lower level programming options
       (some even allow in-circuit debugging). More details are available in the
       <a href="/firmware/index.html">firmware page</a>.
+
     </div>
 
     <div class="tab-pane" id="hardware-devs">
@@ -86,6 +89,9 @@ for the reference VI in your car.
       <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
       GitHub repository (along with the contents of this website).
 
+    </div>
+  </div>
+</div>
 
 <hr/>
 

--- a/index.mkd
+++ b/index.mkd
@@ -41,8 +41,8 @@ for the reference VI in your car.
 <div class="tabbable">
   <ul class="nav nav-tabs">
     <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
-    <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
-    <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
+    <li class="active"><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
+    <li class="active"><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
   </ul>
   <div class="tab-content">
     <div class="active tab-pane" id="app-devs">
@@ -97,12 +97,13 @@ for the reference VI in your car.
 
 <h2>What is this vehicle interface?</h2>
 
+<div>
 The particular unit is a reference design for a "dongle" style vehicle interface
 that connects directly to the diagnostic port with no cable. Ford created this
 design as an iteration from the original, [chipKIT-based vehicle
 interface](https://chipkit-vi.openxcplatform.com) with the goal to:
 
-<!-- * Require no OBD-II cable to connect to the vehicle
+* Require no OBD-II cable to connect to the vehicle
 * Be compact enough to sit directly on the OBD-II port and not hit the driver's
   knees.
 * Include Bluetooth by default
@@ -129,7 +130,8 @@ cables](http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m
 if that's the case.
 
 The current BOM total cost for the electrical components in 1,000 unit
-quantities is around $45. -->
+quantities is around $45.
+</div>
 
 
 ### Features

--- a/index.mkd
+++ b/index.mkd
@@ -40,9 +40,9 @@ for the reference VI in your car.
 
 <div class="tabbable">
   <ul class="nav nav-tabs">
-    <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
-    <li class="active"><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
-    <li class="active"><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
+    <li><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
+    <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
+    <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
   </ul>
   <div class="tab-content">
     <div class="active tab-pane" id="app-devs">
@@ -97,7 +97,6 @@ for the reference VI in your car.
 
 <h2>What is this vehicle interface?</h2>
 
-<div>
 The particular unit is a reference design for a "dongle" style vehicle interface
 that connects directly to the diagnostic port with no cable. Ford created this
 design as an iteration from the original, [chipKIT-based vehicle
@@ -131,7 +130,6 @@ if that's the case.
 
 The current BOM total cost for the electrical components in 1,000 unit
 quantities is around $45.
-</div>
 
 
 ### Features

--- a/index.mkd
+++ b/index.mkd
@@ -41,8 +41,8 @@ for the reference VI in your car.
 <div class="tabbable">
   <ul class="nav nav-tabs">
     <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
-    <li class="active"><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
-    <li class="active"><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
+    <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
+    <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
   </ul>
   <div class="tab-content">
     <div class="active tab-pane" id="app-devs">

--- a/index.mkd
+++ b/index.mkd
@@ -104,64 +104,82 @@ design as an iteration from the original, <a href="https://chipkit-vi.openxcplat
 interface </a> with the goal to:
 </p>
 
-* Require no OBD-II cable to connect to the vehicle
-* Be compact enough to sit directly on the OBD-II port and not hit the driver's
-  knees.
-* Include Bluetooth by default
-* Be powered from the vehicle and not drain the battery when left attached
-* Provide 12v power from the vehicle to an external USB hub for other OpenXC
-  hardware modules
+<ul>
+  <li>Require no OBD-II cable to connect to the vehicle</li>
+  <li>Be compact enough to sit directly on the OBD-II port and not hit the driver's
+  knees</li>
+  <li>Include Bluetooth by default</li>
+  <li>Be powered from the vehicle and not drain the battery when left attached
+  <li>Provide 12v power from the vehicle to an external USB hub for other OpenXC
+  hardware modules</li>
+</ul>
 
+<p>
 This streamlined vehicle interface uses a ARM Cortex-M3 microcontroller (NXP's
 LPC1769), a dual-channel CAN transceiver from NXP, the RN-41 Bluetooth
 module from Roving
 Networks and includes a micro-USB port. The design also includes a 12v port
 (with a Molex connector) to power an external device from the car, and this port
 can be shut off with the car to avoid battery drain.
+</p>
 
+<p>
 We also designed and prototyped a plastic housing for the board that allows it
 to be easily gripped and attached/detached from the OBD-II port underneath the
 steering wheel.
+</p>
 
+<p>
 The device is not as compact as it could be, primarily because we design it to
 use only a 2-layer PCB (to make it more accessible for hobbyists). Depending on
 the placement and angle of the OBD-II port in your vehicle, the VI may protrude
-too much - we recommend one of the many available [OBD-II extension
-cables](http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m-to-j1962f-obd-ii-extension-cable-5ft.html)
-if that's the case.
+too much - we recommend one of the many available <a href="http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m-to-j1962f-obd-ii-extension-cable-5ft.html">OBD-II extension
+cables</a> if that's the case.
+</p>
 
+<p>
 The current BOM total cost for the electrical components in 1,000 unit
 quantities is around $45.
+</p>
 
 
-### Features
+<h2>Features</h2>
 
-* Reads from 2 different CAN buses simultaneously at up to 1Mbps per bus - by
-  default CAN1 and CAN2-1 (according to the [OpenXC naming
-  scheme](http://openxcplatform.com/vehicle-interface/index.html)), with CAN2-2
+<ul>
+  <li>Reads from 2 different CAN buses simultaneously at up to 1Mbps per bus - by
+  default CAN1 and CAN2-1 (according to the <a href="http://openxcplatform.com/vehicle-interface/index.html">OpenXC naming
+  scheme</a>), with CAN2-2
   available behind a solder jumper
-* Can relay vehicle data at up to 250kbps over a Bluetooth connection
-* Can relay vehicle data at up to 11Mbps over a USB connection
-* Passes up to 6A of power from the vehicle to accessories
+  </li>
+  <li>Can relay vehicle data at up to 250kbps over a Bluetooth connection</li>
+  <li>Can relay vehicle data at up to 11Mbps over a USB connection</li>
+  <li>Passes up to 6A of power from the vehicle to accessories</li>
+</ul>
 
-![VI Ports](/static/images/vi-ports.jpg)
+<img src="static/images/vi-ports.jpg" alt="VI Ports">
 
-## Contributors
 
+<h2>Contributors</h2>
+
+<p>
 The electrical reference design was created by Bug Labs, contracted by
 Ford and in
-collaboration with Ford Research and Innovation engineers in both [Palo
-Alto, CA](https://corporate.ford.com/operations/locations/silicon-valley.html) and Dearborn, MI. For a full list of the
-contributors to this project, see the
-[AUTHORS](https://github.com/openxc/reference-vi/blob/gh-pages/AUTHORS) file.
+collaboration with Ford Research and Innovation engineers in both <a href="https://corporate.ford.com/operations/locations/silicon-valley.html">Palo
+Alto, CA</a> and Dearborn, MI. For a full list of the
+contributors to this project, see the <a href="https://github.com/openxc/reference-vi/blob/gh-pages/AUTHORS">AUTHORS</a> file.
+</p>
 
-## License
+<h2>License</h2>
 
+<p>
 Copyright (c) 2013 Ford Motor Company
+</p>
 
+<p>
 This vehicle interface is open source hardware. The electrical and mechanical
-designs in this repository are available under the [Creative Commons Attribution
-4.0 International](http://creativecommons.org/licenses/by/4.0/deed.en_US) license.
+designs in this repository are available under the <a href="http://creativecommons.org/licenses/by/4.0/deed.en_US">Creative Commons Attribution
+4.0 International</a> license.
+</p>
 
 [output-format]: http://openxcplatform.com/vehicle-interface/output-format.html
 [host device]: http://openxcplatform.com/android/index.html

--- a/index.mkd
+++ b/index.mkd
@@ -78,6 +78,7 @@ for the reference VI in your car.
       <p>Alternatively, you can use one of a few lower level programming options
       (some even allow in-circuit debugging). More details are available in the
       <a href="/firmware/index.html">firmware page</a>.
+      </p>
 
   </div>
 
@@ -89,7 +90,7 @@ for the reference VI in your car.
       <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
       GitHub repository (along with the contents of this website).
 
-  </div>
+    
   </div>
 </div>
 
@@ -109,7 +110,7 @@ interface </a> with the goal to:
   <li>Be compact enough to sit directly on the OBD-II port and not hit the driver's
   knees</li>
   <li>Include Bluetooth by default</li>
-  <li>Be powered from the vehicle and not drain the battery when left attached
+  <li>Be powered from the vehicle and not drain the battery when left attached</li>
   <li>Provide 12v power from the vehicle to an external USB hub for other OpenXC
   hardware modules</li>
 </ul>

--- a/index.mkd
+++ b/index.mkd
@@ -102,7 +102,7 @@ that connects directly to the diagnostic port with no cable. Ford created this
 design as an iteration from the original, [chipKIT-based vehicle
 interface](https://chipkit-vi.openxcplatform.com) with the goal to:
 
-* Require no OBD-II cable to connect to the vehicle
+<!-- * Require no OBD-II cable to connect to the vehicle
 * Be compact enough to sit directly on the OBD-II port and not hit the driver's
   knees.
 * Include Bluetooth by default
@@ -129,7 +129,7 @@ cables](http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m
 if that's the case.
 
 The current BOM total cost for the electrical components in 1,000 unit
-quantities is around $45.
+quantities is around $45. -->
 
 
 ### Features

--- a/index.mkd
+++ b/index.mkd
@@ -3,7 +3,9 @@ layout: default
 title: OpenXC Vehicle Interface Reference Design
 section: overview
 ---
+
 <h2>What is OpenXC?</h2>
+
 [OpenXC](http://openxcplatform.com) is an API to your car - by installing a small hardware module
 to read and translate metrics from a car's internal network, the data becomes
 accessible from most Android applications using the OpenXC library. You can
@@ -14,30 +16,40 @@ This website is the documentation for a reference design of an OpenXC-compatible
 [Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)  -
 for more information on the platform in general, visit
 [openxcplatform.com](http://openxcplatform.com).
+
 ![Vehicle Interface](/static/images/vi-surface.png)
 ![Vehicle Interface Opened Up](/static/images/vi-packaging.png)
+
 The [Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)
 (VI) is piece of hardware that connects to the car's CAN bus, translates
 proprietary CAN messages to the standard [OpenXC message format](http://openxcplatform.com/vehicle-interface/output-format.html)
 and sends the output over a common interface like USB to a [host device](http://openxcplatform.com/host-devices/hardware.html) -
 this particular implementation has USB and Bluetooth.
+
 Ford created this design and manufactured a small quantity to seed the developer
 community. If you have an idea for an OpenXC application and this hardware would
 help, make sure there aren't [any known issues
 with
 the fit](https://github.com/openxc/openxcplatform.com/wiki/Vehicle-interface-physical-fit-compatibility)
 for the reference VI in your car.
+
 ![Vehicle Interface Open](/static/images/vi-opening.jpg)
 ![Vehicle Interface Installed in Vehicle](/static/images/vi-installed-in-vehicle.jpg)
+
 <h2>Quick Start</h2>
+
 <div class="tabbable">
+
     <ul class="nav nav-tabs">
         <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
         <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
         <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
     </ul>
+
     <div class="tab-content">
+
         <div class="active tab-pane" id="app-devs">
+
             <p>The VI needs to be programmed with firmware before you can get data
                 from a car. You can use the <a href="https://github.com/openxc/vi-firmware/releases">emulator
                     firmware (zip file)</a> to test the data connection to a <a
@@ -46,41 +58,56 @@ for the reference VI in your car.
                 of the <a href="http://openxcplatform.com/vehicle-interface/firmware.html">other
                     available firmwares</a>.
             </p>
+
             <p>Once you've downloaded a firmware file (it should be a version for the
                 "FORDBOARD" and have the ".bin" extension) programming the VI is simple -
                 follow the <a href="/firmware/programming/usb.html">USB programming
                     instructions</a>.
             </p>
+
         </div>
+
         <div class="active tab-pane" id="firmware-devs">
+
             <p>Besides using <a href="http://openxcplatform.com/vehicle-interface/firmware.html">binary
                     firmware for app developers</a>, you can build your own code to run on the
                 VI. You can use the <a href="http://vi-firmware.openxcplatform.com">official OpenXC VI
                     firmware</a> (the source for most binary firmware, e.g. those from Ford)
                 or start from scratch with a <a href="https://github.com/openxc/lpc17xx-starter">blank project</a>.</p>
+
             <p>Alternatively, you can use one of a few lower level programming options
                 (some even allow in-circuit debugging). More details are available in the
                 <a href="/firmware/index.html">firmware page</a>.
             </p>
+
         </div>
+
         <div class="active tab-pane" id="hardware-devs">
+
             <p>This site contains complete documentation of the hardware,
                 design motivations, fabrication and testing plans. Every component is
                 released as open source hardware and the source files are available in the
                 <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
                 GitHub repository (along with the contents of this website).
             </p>
+
         </div>
+
     </div>
+
 </div>
+
 <hr />
+
 <h2>What is this vehicle interface?</h2>
+
 <p>
     The particular unit is a reference design for a "dongle" style vehicle interface
     that connects directly to the diagnostic port with no cable. Ford created this
     design as an iteration from the original, <a href="https://chipkit-vi.openxcplatform.com"> chipKIT-based vehicle
         interface </a> with the goal to:
 </p>
+
 <ul>
     <li>Require no OBD-II cable to connect to the vehicle</li>
     <li>Be compact enough to sit directly on the OBD-II port and not hit the driver's
@@ -90,6 +117,7 @@ for the reference VI in your car.
     <li>Provide 12v power from the vehicle to an external USB hub for other OpenXC
         hardware modules</li>
 </ul>
+
 <p>
     This streamlined vehicle interface uses a ARM Cortex-M3 microcontroller (NXP's
     LPC1769), a dual-channel CAN transceiver from NXP, the RN-41 Bluetooth
@@ -98,11 +126,13 @@ for the reference VI in your car.
     (with a Molex connector) to power an external device from the car, and this port
     can be shut off with the car to avoid battery drain.
 </p>
+
 <p>
     We also designed and prototyped a plastic housing for the board that allows it
     to be easily gripped and attached/detached from the OBD-II port underneath the
     steering wheel.
 </p>
+
 <p>
     The device is not as compact as it could be, primarily because we design it to
     use only a 2-layer PCB (to make it more accessible for hobbyists). Depending on
@@ -112,11 +142,15 @@ for the reference VI in your car.
         extension
         cables</a> if that's the case.
 </p>
+
 <p>
     The current BOM total cost for the electrical components in 1,000 unit
     quantities is around $45.
 </p>
+
+
 <h2>Features</h2>
+
 <ul>
     <li>Reads from 2 different CAN buses simultaneously at up to 1Mbps per bus - by
         default CAN1 and CAN2-1 (according to the <a
@@ -128,8 +162,12 @@ for the reference VI in your car.
     <li>Can relay vehicle data at up to 11Mbps over a USB connection</li>
     <li>Passes up to 6A of power from the vehicle to accessories</li>
 </ul>
+
 <img src="static/images/vi-ports.jpg" alt="VI Ports">
+
+
 <h2>Contributors</h2>
+
 <p>
     The electrical reference design was created by Bug Labs, contracted by
     Ford and in
@@ -139,10 +177,14 @@ for the reference VI in your car.
     contributors to this project, see the <a
         href="https://github.com/openxc/reference-vi/blob/gh-pages/AUTHORS">AUTHORS</a> file.
 </p>
+
+
 <h2>License</h2>
+
 <p>
     Copyright (c) 2013 Ford Motor Company
 </p>
+
 <p>
     This vehicle interface is open source hardware. The electrical and mechanical
     designs in this repository are available under the <a

--- a/index.mkd
+++ b/index.mkd
@@ -62,8 +62,6 @@ for the reference VI in your car.
       follow the <a href="/firmware/programming/usb.html">USB programming
       instructions</a>.</p>
 
-    </div>
-
     <div class="tab-pane" id="firmware-devs">
 
       <p>Besides using <a
@@ -78,7 +76,6 @@ for the reference VI in your car.
       <p>Alternatively, you can use one of a few lower level programming options
       (some even allow in-circuit debugging). More details are available in the
       <a href="/firmware/index.html">firmware page</a>.
-
     </div>
 
     <div class="tab-pane" id="hardware-devs">
@@ -89,9 +86,6 @@ for the reference VI in your car.
       <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
       GitHub repository (along with the contents of this website).
 
-    </div>
-  </div>
-</div>
 
 <hr/>
 

--- a/index.mkd
+++ b/index.mkd
@@ -41,8 +41,8 @@ for the reference VI in your car.
 <div class="tabbable">
   <ul class="nav nav-tabs">
     <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
-    <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
-    <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
+    <li class="active"><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
+    <li class="active"><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
   </ul>
   <div class="tab-content">
     <div class="active tab-pane" id="app-devs">
@@ -62,9 +62,9 @@ for the reference VI in your car.
       follow the <a href="/firmware/programming/usb.html">USB programming
       instructions</a>.</p>
 
-    </div>
+  </div>
 
-    <div class="tab-pane" id="firmware-devs">
+  <div class="active tab-pane" id="firmware-devs">
 
       <p>Besides using <a
       href="http://openxcplatform.com/vehicle-interface/firmware.html">binary
@@ -79,9 +79,9 @@ for the reference VI in your car.
       (some even allow in-circuit debugging). More details are available in the
       <a href="/firmware/index.html">firmware page</a>.
 
-    </div>
+  </div>
 
-    <div class="tab-pane" id="hardware-devs">
+  <div class="active tab-pane" id="hardware-devs">
 
       <p>This site contains complete documentation of the hardware,
       design motivations, fabrication and testing plans. Every component is
@@ -89,7 +89,7 @@ for the reference VI in your car.
       <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
       GitHub repository (along with the contents of this website).
 
-    </div>
+  </div>
   </div>
 </div>
 

--- a/index.mkd
+++ b/index.mkd
@@ -3,9 +3,7 @@ layout: default
 title: OpenXC Vehicle Interface Reference Design
 section: overview
 ---
-
 <h2>What is OpenXC?</h2>
-
 [OpenXC](http://openxcplatform.com) is an API to your car - by installing a small hardware module
 to read and translate metrics from a car's internal network, the data becomes
 accessible from most Android applications using the OpenXC library. You can
@@ -13,171 +11,143 @@ start making vehicle-aware applications that have better interfaces based on
 context, can minimize distraction while driving, are integrated with other
 connected services, and can offer you more insight into your car's operation.
 This website is the documentation for a reference design of an OpenXC-compatible
-[Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)  -
+[Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html) -
 for more information on the platform in general, visit
 [openxcplatform.com](http://openxcplatform.com).
-
 ![Vehicle Interface](/static/images/vi-surface.png)
 ![Vehicle Interface Opened Up](/static/images/vi-packaging.png)
-
 The [Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)
 (VI) is piece of hardware that connects to the car's CAN bus, translates
-proprietary CAN messages to the standard [OpenXC message format](http://openxcplatform.com/vehicle-interface/output-format.html)
-and sends the output over a common interface like USB to a [host device](http://openxcplatform.com/host-devices/hardware.html) -
+proprietary CAN messages to the standard [OpenXC message
+format](http://openxcplatform.com/vehicle-interface/output-format.html)
+and sends the output over a common interface like USB to a [host
+device](http://openxcplatform.com/host-devices/hardware.html) -
 this particular implementation has USB and Bluetooth.
-
 Ford created this design and manufactured a small quantity to seed the developer
 community. If you have an idea for an OpenXC application and this hardware would
 help, make sure there aren't [any known issues
 with
 the fit](https://github.com/openxc/openxcplatform.com/wiki/Vehicle-interface-physical-fit-compatibility)
 for the reference VI in your car.
-
 ![Vehicle Interface Open](/static/images/vi-opening.jpg)
 ![Vehicle Interface Installed in Vehicle](/static/images/vi-installed-in-vehicle.jpg)
-
 <h2>Quick Start</h2>
-
 <div class="tabbable">
-  <ul class="nav nav-tabs">
-    <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
-    <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
-    <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
-  </ul>
-  <div class="tab-content">
-    <div class="active tab-pane" id="app-devs">
-
-      <p>The VI needs to be programmed with firmware before you can get data
-      from a car. You can use the <a
-      href="https://github.com/openxc/vi-firmware/releases">emulator
-      firmware (zip file)</a> to test the data connection to a <a
-      href="http://openxcplatform.com/host-devices/index.html">host device</a>
-      (a computer, smartphone or tablet). To get data from a real car, grab one
-      of the <a
-      href="http://openxcplatform.com/vehicle-interface/firmware.html">other
-      available firmwares</a>.</p>
-
-      <p>Once you've downloaded a firmware file (it should be a version for the
-      "FORDBOARD" and have the ".bin" extension) programming the VI is simple -
-      follow the <a href="/firmware/programming/usb.html">USB programming
-      instructions</a>.</p>
-
-  </div>
-
-  <div class="active tab-pane" id="firmware-devs">
-
-      <p>Besides using <a
-      href="http://openxcplatform.com/vehicle-interface/firmware.html">binary
-      firmware for app developers</a>, you can build your own code to run on the
-      VI. You can use the <a
-      href="http://vi-firmware.openxcplatform.com">official OpenXC VI
-      firmware</a> (the source for most binary firmware, e.g. those from Ford)
-      or start from scratch with a <a
-      href="https://github.com/openxc/lpc17xx-starter">blank project</a>.</p>
-
-      <p>Alternatively, you can use one of a few lower level programming options
-      (some even allow in-circuit debugging). More details are available in the
-      <a href="/firmware/index.html">firmware page</a>.
-      </p>
-
-  </div>
-
-  <div class="active tab-pane" id="hardware-devs">
-
-      <p>This site contains complete documentation of the hardware,
-      design motivations, fabrication and testing plans. Every component is
-      released as open source hardware and the source files are available in the
-      <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
-      GitHub repository (along with the contents of this website).
-
-    
-  </div>
+    <ul class="nav nav-tabs">
+        <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
+        <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
+        <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
+    </ul>
+    <div class="tab-content">
+        <div class="active tab-pane" id="app-devs">
+            <p>The VI needs to be programmed with firmware before you can get data
+                from a car. You can use the <a href="https://github.com/openxc/vi-firmware/releases">emulator
+                    firmware (zip file)</a> to test the data connection to a <a
+                    href="http://openxcplatform.com/host-devices/index.html">host device</a>
+                (a computer, smartphone or tablet). To get data from a real car, grab one
+                of the <a href="http://openxcplatform.com/vehicle-interface/firmware.html">other
+                    available firmwares</a>.
+            </p>
+            <p>Once you've downloaded a firmware file (it should be a version for the
+                "FORDBOARD" and have the ".bin" extension) programming the VI is simple -
+                follow the <a href="/firmware/programming/usb.html">USB programming
+                    instructions</a>.
+            </p>
+        </div>
+        <div class="active tab-pane" id="firmware-devs">
+            <p>Besides using <a href="http://openxcplatform.com/vehicle-interface/firmware.html">binary
+                    firmware for app developers</a>, you can build your own code to run on the
+                VI. You can use the <a href="http://vi-firmware.openxcplatform.com">official OpenXC VI
+                    firmware</a> (the source for most binary firmware, e.g. those from Ford)
+                or start from scratch with a <a href="https://github.com/openxc/lpc17xx-starter">blank project</a>.</p>
+            <p>Alternatively, you can use one of a few lower level programming options
+                (some even allow in-circuit debugging). More details are available in the
+                <a href="/firmware/index.html">firmware page</a>.
+            </p>
+        </div>
+        <div class="active tab-pane" id="hardware-devs">
+            <p>This site contains complete documentation of the hardware,
+                design motivations, fabrication and testing plans. Every component is
+                released as open source hardware and the source files are available in the
+                <a href="https://github.com/openxc/reference-vi">openxc/reference-vi</a>
+                GitHub repository (along with the contents of this website).
+            </p>
+        </div>
+    </div>
 </div>
-
-<hr/>
-
+<hr />
 <h2>What is this vehicle interface?</h2>
-
 <p>
-The particular unit is a reference design for a "dongle" style vehicle interface
-that connects directly to the diagnostic port with no cable. Ford created this
-design as an iteration from the original, <a href="https://chipkit-vi.openxcplatform.com"> chipKIT-based vehicle
-interface </a> with the goal to:
+    The particular unit is a reference design for a "dongle" style vehicle interface
+    that connects directly to the diagnostic port with no cable. Ford created this
+    design as an iteration from the original, <a href="https://chipkit-vi.openxcplatform.com"> chipKIT-based vehicle
+        interface </a> with the goal to:
 </p>
-
 <ul>
-  <li>Require no OBD-II cable to connect to the vehicle</li>
-  <li>Be compact enough to sit directly on the OBD-II port and not hit the driver's
-  knees</li>
-  <li>Include Bluetooth by default</li>
-  <li>Be powered from the vehicle and not drain the battery when left attached</li>
-  <li>Provide 12v power from the vehicle to an external USB hub for other OpenXC
-  hardware modules</li>
+    <li>Require no OBD-II cable to connect to the vehicle</li>
+    <li>Be compact enough to sit directly on the OBD-II port and not hit the driver's
+        knees</li>
+    <li>Include Bluetooth by default</li>
+    <li>Be powered from the vehicle and not drain the battery when left attached</li>
+    <li>Provide 12v power from the vehicle to an external USB hub for other OpenXC
+        hardware modules</li>
 </ul>
-
 <p>
-This streamlined vehicle interface uses a ARM Cortex-M3 microcontroller (NXP's
-LPC1769), a dual-channel CAN transceiver from NXP, the RN-41 Bluetooth
-module from Roving
-Networks and includes a micro-USB port. The design also includes a 12v port
-(with a Molex connector) to power an external device from the car, and this port
-can be shut off with the car to avoid battery drain.
+    This streamlined vehicle interface uses a ARM Cortex-M3 microcontroller (NXP's
+    LPC1769), a dual-channel CAN transceiver from NXP, the RN-41 Bluetooth
+    module from Roving
+    Networks and includes a micro-USB port. The design also includes a 12v port
+    (with a Molex connector) to power an external device from the car, and this port
+    can be shut off with the car to avoid battery drain.
 </p>
-
 <p>
-We also designed and prototyped a plastic housing for the board that allows it
-to be easily gripped and attached/detached from the OBD-II port underneath the
-steering wheel.
+    We also designed and prototyped a plastic housing for the board that allows it
+    to be easily gripped and attached/detached from the OBD-II port underneath the
+    steering wheel.
 </p>
-
 <p>
-The device is not as compact as it could be, primarily because we design it to
-use only a 2-layer PCB (to make it more accessible for hobbyists). Depending on
-the placement and angle of the OBD-II port in your vehicle, the VI may protrude
-too much - we recommend one of the many available <a href="http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m-to-j1962f-obd-ii-extension-cable-5ft.html">OBD-II extension
-cables</a> if that's the case.
+    The device is not as compact as it could be, primarily because we design it to
+    use only a 2-layer PCB (to make it more accessible for hobbyists). Depending on
+    the placement and angle of the OBD-II port in your vehicle, the VI may protrude
+    too much - we recommend one of the many available <a
+        href="http://www.obd2cables.com/products/obd-cables/obd-ii-cables/cable-j1962m-to-j1962f-obd-ii-extension-cable-5ft.html">OBD-II
+        extension
+        cables</a> if that's the case.
 </p>
-
 <p>
-The current BOM total cost for the electrical components in 1,000 unit
-quantities is around $45.
+    The current BOM total cost for the electrical components in 1,000 unit
+    quantities is around $45.
 </p>
-
-
 <h2>Features</h2>
-
 <ul>
-  <li>Reads from 2 different CAN buses simultaneously at up to 1Mbps per bus - by
-  default CAN1 and CAN2-1 (according to the <a href="http://openxcplatform.com/vehicle-interface/index.html">OpenXC naming
-  scheme</a>), with CAN2-2
-  available behind a solder jumper
-  </li>
-  <li>Can relay vehicle data at up to 250kbps over a Bluetooth connection</li>
-  <li>Can relay vehicle data at up to 11Mbps over a USB connection</li>
-  <li>Passes up to 6A of power from the vehicle to accessories</li>
+    <li>Reads from 2 different CAN buses simultaneously at up to 1Mbps per bus - by
+        default CAN1 and CAN2-1 (according to the <a
+            href="http://openxcplatform.com/vehicle-interface/index.html">OpenXC naming
+            scheme</a>), with CAN2-2
+        available behind a solder jumper
+    </li>
+    <li>Can relay vehicle data at up to 250kbps over a Bluetooth connection</li>
+    <li>Can relay vehicle data at up to 11Mbps over a USB connection</li>
+    <li>Passes up to 6A of power from the vehicle to accessories</li>
 </ul>
-
 <img src="static/images/vi-ports.jpg" alt="VI Ports">
-
-
 <h2>Contributors</h2>
-
 <p>
-The electrical reference design was created by Bug Labs, contracted by
-Ford and in
-collaboration with Ford Research and Innovation engineers in both <a href="https://corporate.ford.com/operations/locations/silicon-valley.html">Palo
-Alto, CA</a> and Dearborn, MI. For a full list of the
-contributors to this project, see the <a href="https://github.com/openxc/reference-vi/blob/gh-pages/AUTHORS">AUTHORS</a> file.
+    The electrical reference design was created by Bug Labs, contracted by
+    Ford and in
+    collaboration with Ford Research and Innovation engineers in both <a
+        href="https://corporate.ford.com/operations/locations/silicon-valley.html">Palo
+        Alto, CA</a> and Dearborn, MI. For a full list of the
+    contributors to this project, see the <a
+        href="https://github.com/openxc/reference-vi/blob/gh-pages/AUTHORS">AUTHORS</a> file.
 </p>
-
 <h2>License</h2>
-
 <p>
-Copyright (c) 2013 Ford Motor Company
+    Copyright (c) 2013 Ford Motor Company
 </p>
-
 <p>
-This vehicle interface is open source hardware. The electrical and mechanical
-designs in this repository are available under the <a href="http://creativecommons.org/licenses/by/4.0/deed.en_US">Creative Commons Attribution
-4.0 International</a> license.
+    This vehicle interface is open source hardware. The electrical and mechanical
+    designs in this repository are available under the <a
+        href="http://creativecommons.org/licenses/by/4.0/deed.en_US">Creative Commons Attribution
+        4.0 International</a> license.
 </p>

--- a/index.mkd
+++ b/index.mkd
@@ -40,7 +40,7 @@ for the reference VI in your car.
 
 <div class="tabbable">
   <ul class="nav nav-tabs">
-    <li><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
+    <li class="active"><a href="#app-devs" data-toggle="tab">For App Developers</a></li>
     <li><a href="#firmware-devs" data-toggle="tab">For Firmware Developers</a></li>
     <li><a href="#hardware-devs" data-toggle="tab">For Hardware Developers</a></li>
   </ul>
@@ -97,10 +97,12 @@ for the reference VI in your car.
 
 <h2>What is this vehicle interface?</h2>
 
+<p>
 The particular unit is a reference design for a "dongle" style vehicle interface
 that connects directly to the diagnostic port with no cable. Ford created this
-design as an iteration from the original, [chipKIT-based vehicle
-interface](https://chipkit-vi.openxcplatform.com) with the goal to:
+design as an iteration from the original, <a href="https://chipkit-vi.openxcplatform.com"> chipKIT-based vehicle
+interface </a> with the goal to:
+</p>
 
 * Require no OBD-II cable to connect to the vehicle
 * Be compact enough to sit directly on the OBD-II port and not hit the driver's

--- a/index.mkd
+++ b/index.mkd
@@ -180,7 +180,3 @@ This vehicle interface is open source hardware. The electrical and mechanical
 designs in this repository are available under the <a href="http://creativecommons.org/licenses/by/4.0/deed.en_US">Creative Commons Attribution
 4.0 International</a> license.
 </p>
-
-[output-format]: http://openxcplatform.com/vehicle-interface/output-format.html
-[host device]: http://openxcplatform.com/android/index.html
-[openxc]: http://openxcplatform.com

--- a/index.mkd
+++ b/index.mkd
@@ -11,17 +11,15 @@ start making vehicle-aware applications that have better interfaces based on
 context, can minimize distraction while driving, are integrated with other
 connected services, and can offer you more insight into your car's operation.
 This website is the documentation for a reference design of an OpenXC-compatible
-[Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html) -
+[Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)  -
 for more information on the platform in general, visit
 [openxcplatform.com](http://openxcplatform.com).
 ![Vehicle Interface](/static/images/vi-surface.png)
 ![Vehicle Interface Opened Up](/static/images/vi-packaging.png)
 The [Vehicle Interface](http://openxcplatform.com/vehicle-interface/index.html)
 (VI) is piece of hardware that connects to the car's CAN bus, translates
-proprietary CAN messages to the standard [OpenXC message
-format](http://openxcplatform.com/vehicle-interface/output-format.html)
-and sends the output over a common interface like USB to a [host
-device](http://openxcplatform.com/host-devices/hardware.html) -
+proprietary CAN messages to the standard [OpenXC message format](http://openxcplatform.com/vehicle-interface/output-format.html)
+and sends the output over a common interface like USB to a [host device](http://openxcplatform.com/host-devices/hardware.html) -
 this particular implementation has USB and Bluetooth.
 Ford created this design and manufactured a small quantity to seed the developer
 community. If you have an idea for an OpenXC application and this hardware would

--- a/index.mkd
+++ b/index.mkd
@@ -100,7 +100,7 @@ for the reference VI in your car.
 The particular unit is a reference design for a "dongle" style vehicle interface
 that connects directly to the diagnostic port with no cable. Ford created this
 design as an iteration from the original, [chipKIT-based vehicle
-interface](http://chipkit-vi.openxcplatform.com) with the goal to:
+interface](https://chipkit-vi.openxcplatform.com) with the goal to:
 
 * Require no OBD-II cable to connect to the vehicle
 * Be compact enough to sit directly on the OBD-II port and not hit the driver's


### PR DESCRIPTION
This PR removes any mention of Bootloader v1.0.  We are assuming that all users are using Bootloader v1.1 going forward.  
Also fixed:

- Fix broken Markdown format on the home page.  Replacing the Broken Markdown with HTML and CSS as a temporary fix.  After researching why the Markdown is not rendering properly on our website, it appears as though it's a current issue that has not been resolved yet.  

- On the home page I noticed tab links were broken for "For App Developers", "For Firmware Developers", and "For Hardware Developers." Each tab now functions correctly.  

